### PR TITLE
fix: disable body and footer max line length in commitlint

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -22,6 +22,7 @@ module.exports = {
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],
     'header-max-length': [2, 'always', 72],
-    'body-max-line-length': [2, 'always', 100],
+    'body-max-line-length': [0, 'always', 100],
+    'footer-max-line-length': [0, 'always', 100],
   },
 };


### PR DESCRIPTION
## Summary
- Disables `body-max-line-length` and `footer-max-line-length` rules in commitlint configuration
- Fixes semantic-release failures caused by long URLs in generated commit messages

## Problem
The semantic-release tool was failing because it generates commit messages with long URLs that exceed the 100 character limit enforced by commitlint. This was causing release builds to fail with the error:
```
✖   footer's lines must not be longer than 100 characters [footer-max-line-length]
```

## Solution
Modified `commitlint.config.cjs` to disable the problematic rules:
- Set `body-max-line-length` to `[0, 'always', 100]` (disabled)  
- Set `footer-max-line-length` to `[0, 'always', 100]` (disabled)

This allows semantic-release to create commits with long GitHub URLs while maintaining other commit message validation rules.

## Test plan
- [x] Verified commitlint passes with long commit messages
- [x] All tests pass
- [x] Build succeeds
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)