### PR TITLE
ci: run release job on Node 22 (required by semantic-release 25)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -320,7 +320,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
The Release job failed on main after #121: semantic-release 25 requires node `^22.14.0 || >= 24.10.0` but the job runs Node 20 ([failing run](https://github.com/pablo-albaladejo/trainingpeaks-sdk/actions)). One-line bump of the Release job's `setup-node` to Node 22 — the validate/test matrix (20.x + 22.x) is unchanged.

`ci:` commit → no npm release triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)