### PR TITLE
ci: bump actions to node24 runtimes + dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,15 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "pablo-albaladejo"
+    assignees:
+      - "pablo-albaladejo"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Cache validation results
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .eslintcache
@@ -60,10 +60,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -72,7 +72,7 @@ jobs:
         run: npm ci
 
       - name: Cache test artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             coverage/
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           file: ./coverage/lcov.info
           flags: unittests
@@ -112,10 +112,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -144,10 +144,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -156,7 +156,7 @@ jobs:
         run: npm ci
 
       - name: Cache build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             dist/
@@ -182,7 +182,7 @@ jobs:
 
       - name: Comment bundle analysis (PR only)
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -273,7 +273,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -313,12 +313,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -328,7 +328,7 @@ jobs:
         run: npm ci
 
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             dist/


### PR DESCRIPTION
Long-term fix for the "Node.js 20 is deprecated" warnings, same treatment as kaiord#964:

- **checkout v4 → v7, setup-node v4 → v6, cache v4 → v6, github-script v7 → v9, codecov-action v4 → v7** — all majors already running green in kaiord's CI. `trufflehog` stays SHA-style pinned.
- **New `github-actions` Dependabot ecosystem** (weekly) so action pins never rot again — until now only npm was scanned.

No workflow logic changes; node-version matrices untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)