### PR TITLE
chore(deps): bump @faker-js/faker 9→10 and tough-cookie 5→6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,14 @@
         "form-data": "^4.0.1",
         "playwright-core": "^1.54.1",
         "rosie": "^2.1.1",
-        "tough-cookie": "^5.1.2",
+        "tough-cookie": "^6.0.0",
         "zod": "^4.0.5"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@eslint/js": "^9.33.0",
-        "@faker-js/faker": "^9.2.0",
+        "@faker-js/faker": "^10.1.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^11.0.3",
@@ -1171,9 +1171,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
-      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.5.0.tgz",
+      "integrity": "sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==",
       "dev": true,
       "funding": [
         {
@@ -1183,8 +1183,8 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@humanfs/core": {
@@ -12945,21 +12945,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.86"
+        "tldts-core": "^7.4.9"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -12976,12 +12976,12 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^6.1.32"
+        "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@eslint/js": "^9.33.0",
-    "@faker-js/faker": "^9.2.0",
+    "@faker-js/faker": "^10.1.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.3",
@@ -143,7 +143,7 @@
     "form-data": "^4.0.1",
     "playwright-core": "^1.54.1",
     "rosie": "^2.1.1",
-    "tough-cookie": "^5.1.2",
+    "tough-cookie": "^6.0.0",
     "zod": "^4.0.5"
   }
 }

--- a/src/__fixtures__/auth.fixture.ts
+++ b/src/__fixtures__/auth.fixture.ts
@@ -171,7 +171,7 @@ export const sessionBuilder = new Factory<Session>()
  * Creates Credentials value objects with validation patterns
  */
 export const credentialsBuilder = new Factory<Credentials>()
-  .attr('username', () => faker.internet.userName())
+  .attr('username', () => faker.internet.username())
   .attr('password', () => faker.internet.password())
   .after((credentials, options) => {
     return {
@@ -401,7 +401,7 @@ export const userInfoResponseBuilder = new Factory<UserInfoResponse>()
   .attr('data', () => ({
     user: {
       userId: faker.string.uuid(),
-      username: faker.internet.userName(),
+      username: faker.internet.username(),
       name: faker.person.fullName(),
       preferences: userPreferencesBuilder.build(),
     },
@@ -501,7 +501,7 @@ export const loginResponseBuilder = new Factory<LoginResponse>()
 export const userApiResponseBuilder = new Factory<UserApiResponse>()
   .attr('user', () => ({
     userId: faker.string.uuid(),
-    username: faker.internet.userName(),
+    username: faker.internet.username(),
     name: faker.person.fullName(),
     preferences: userPreferencesBuilder.build(),
   }))

--- a/src/__fixtures__/client-responses.fixture.ts
+++ b/src/__fixtures__/client-responses.fixture.ts
@@ -13,7 +13,7 @@ export const createSuccessResponse = () => ({
   success: true,
   user: {
     id: faker.string.uuid(),
-    username: faker.internet.userName(),
+    username: faker.internet.username(),
     email: faker.internet.email(),
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
@@ -35,7 +35,7 @@ export const UserResponseFactory = new Factory<UserResponse>()
   .attr('success', true)
   .attr('user', () => ({
     id: faker.string.uuid(),
-    username: faker.internet.userName(),
+    username: faker.internet.username(),
     email: faker.internet.email(),
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),

--- a/src/__fixtures__/credentials.fixture.ts
+++ b/src/__fixtures__/credentials.fixture.ts
@@ -10,7 +10,7 @@ import type { Credentials } from '@/domain/schemas';
 
 // Simple credentials using Faker
 export const createValidCredentials = () => ({
-  username: faker.internet.userName(),
+  username: faker.internet.username(),
   password: faker.internet.password({ length: 12 }),
 });
 
@@ -25,12 +25,12 @@ export const createEmptyCredentials = () => ({
 });
 
 export const createMalformedCredentials = () => ({
-  username: faker.internet.userName() + '@#$%^&*()',
+  username: faker.internet.username() + '@#$%^&*()',
   password: faker.internet.password() + '!@#$%^&*()',
 });
 
 export const createLongCredentials = () => ({
-  username: faker.internet.userName().repeat(100),
+  username: faker.internet.username().repeat(100),
   password: faker.internet.password().repeat(100),
 });
 
@@ -41,7 +41,7 @@ export const createSpecialCharacterCredentials = () => ({
 
 // Complex credentials using Rosie Factory
 export const CredentialsFactory = new Factory<Credentials>()
-  .attr('username', () => faker.internet.userName())
+  .attr('username', () => faker.internet.username())
   .attr('password', () => faker.internet.password({ length: 12 }));
 
 // Environment-based credentials for real testing


### PR DESCRIPTION
Closes the two remaining major Dependabot bumps that #121 couldn't take automatically, done together with the required code fix.

- **@faker-js/faker 9 → 10** (dev): v10 renamed `faker.internet.userName` → `faker.internet.username`. Updated the 9 fixture call sites. `faker.datatype.boolean` is unchanged.
- **tough-cookie 5 → 6** (runtime, via `axios-cookiejar-support@^6`): API- and type-compatible; no code changes needed.

Supersedes Dependabot #108 (faker) and #71 (tough-cookie).

## Validation
- ✅ lint · type-check · format:check · ESM+CJS build
- ✅ 601/601 unit tests
- Integration tests need live TrainingPeaks credentials — not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)